### PR TITLE
Route setting for Lumen version > 5.5

### DIFF
--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -19,8 +19,8 @@ class CaptchaServiceProvider extends ServiceProvider {
     public function boot()
     {
         // HTTP routing
-        $this->app->get('captchaInfo[/{type}]', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptchaInfo');
-        $this->app->get('captcha/{type}/{captchaId}', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptcha');
+        $this->app->router->get('captchaInfo[/{type}]', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptchaInfo');
+        $this->app->router->get('captcha/{type}/{captchaId}', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptcha');
 
         // Validator extensions
         $this->app['validator']->extend('captcha', function($attribute, $value, $parameters)


### PR DESCRIPTION
Start from Lumen 5.5, routing use "$this->app->router" instead of "$app" variable.
ps: "$this->app->router" will be passed to "routes/web.php" at "bootstrap/app.php", therefore routes/web.php use "$router".